### PR TITLE
Cannot select authentication service after update to version 2.0.x #57

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -31,6 +31,9 @@
   <name>Microsoft Entra ID SSO API</name>
   <description>This extension allows users to authenticate to the wiki using Entra ID, formerly known as Azure Active Directory.</description>
   <properties>
+    <!-- This module is a leftover dependency from the old Azure OAuth version, and it is no longer needed as its
+      functionalities have been replaced by OIDC. Removing this module is also necessary to allow the user to select
+      the Authentication service. -->
     <xwiki.extension.features>com.xwiki.identity-oauth:identity-oauth-api</xwiki.extension.features>
   </properties>
   <dependencies>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -30,7 +30,9 @@
 
   <name>Microsoft Entra ID SSO API</name>
   <description>This extension allows users to authenticate to the wiki using Entra ID, formerly known as Azure Active Directory.</description>
-
+  <properties>
+    <xwiki.extension.features>com.xwiki.identity-oauth:identity-oauth-api</xwiki.extension.features>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>com.github.scribejava</groupId>

--- a/api/src/main/java/com/xwiki/azureoauth/internal/AzureADOIDCMigrator.java
+++ b/api/src/main/java/com/xwiki/azureoauth/internal/AzureADOIDCMigrator.java
@@ -170,12 +170,7 @@ public class AzureADOIDCMigrator
             String.format(BASE_ENDPOINT, tenantID, "logout"));
     }
 
-    /**
-     * Get the current wiki from context.
-     *
-     * @return the current wiki, or null if the context is not yet initialized.
-     */
-    public XWiki getXWiki()
+    private XWiki getXWiki()
     {
         XWikiContext xcontext = this.xcontextProvider.get();
 

--- a/api/src/main/java/com/xwiki/azureoauth/internal/AzureADOIDCMigrator.java
+++ b/api/src/main/java/com/xwiki/azureoauth/internal/AzureADOIDCMigrator.java
@@ -97,6 +97,9 @@ public class AzureADOIDCMigrator
     @Inject
     private Logger logger;
 
+    @Inject
+    private Provider<XWikiContext> xcontextProvider;
+
     /**
      * Check if the current EntraID/OIDC configuration is empty and populate it with the old configuration from Azure
      * AD.
@@ -105,16 +108,20 @@ public class AzureADOIDCMigrator
      */
     public void initializeOIDCConfiguration() throws ConfigurationSaveException
     {
-        EntraIDConfiguration entraIDConfiguration = entraIDConfigurationProvider.get();
-        Map<String, Object> configurationMap = generateNewConfiguration();
-        if (entraIDConfiguration.getTenantID().isEmpty()) {
-            entraIDConfiguration.setEntraIDConfiguration(getTenantIdConfiguration());
-            configurationMap.putAll(getEndpoints(identityOAuthConfigurationProvider.get().getTenantID()));
-            logger.info("Successfully set Entra ID configuration.");
-        }
-        if (!configurationMap.isEmpty()) {
-            entraIDConfiguration.setOIDCConfiguration(configurationMap);
-            logger.info("Successfully set OIDC configuration.");
+        // XWiki might not be fully initialized yet, in which case it means we are not attempting to update the
+        // configuration.
+        if (getXWiki() != null) {
+            EntraIDConfiguration entraIDConfiguration = entraIDConfigurationProvider.get();
+            Map<String, Object> configurationMap = generateNewConfiguration();
+            if (entraIDConfiguration.getTenantID().isEmpty()) {
+                entraIDConfiguration.setEntraIDConfiguration(getTenantIdConfiguration());
+                configurationMap.putAll(getEndpoints(identityOAuthConfigurationProvider.get().getTenantID()));
+                logger.info("Successfully set Entra ID configuration.");
+            }
+            if (!configurationMap.isEmpty()) {
+                entraIDConfiguration.setOIDCConfiguration(configurationMap);
+                logger.info("Successfully set OIDC configuration.");
+            }
         }
     }
 
@@ -126,21 +133,26 @@ public class AzureADOIDCMigrator
      */
     public void refactorOIDCIssuer() throws QueryException, XWikiException
     {
-        List<String> results = this.queryManager.createQuery(
-                ", BaseObject as obj where doc.fullName = obj.name and obj.className = :className", Query.HQL)
-            .setWiki(this.wikiManager.getCurrentWikiId()).bindValue("className", OIDC_USER_CLASS).execute();
-        XWikiContext wikiContext = wikiContextProvider.get();
-        XWiki wiki = wikiContext.getWiki();
+        XWiki wiki = getXWiki();
 
-        for (String userRef : results) {
-            XWikiDocument userDoc = wiki.getDocument(documentReferenceResolver.resolve(userRef), wikiContext);
-            BaseObject oidcObj = userDoc.getXObject(documentReferenceResolver.resolve(OIDC_USER_CLASS));
-            String issuer = oidcObj.getField(ISSUER).toFormString();
-            if (issuer.endsWith(INVALID_VERSION)) {
-                int index = issuer.lastIndexOf(INVALID_VERSION);
-                String fixedIssuer = issuer.substring(0, index) + VALID_VERSION;
-                oidcObj.set(ISSUER, fixedIssuer, wikiContext);
-                wiki.saveDocument(userDoc, "Refactored OIDC issuer to the right format used by Entra ID.", wikiContext);
+        // XWiki might not be fully initialized yet, in which case it means we are not attempting to update the users.
+        if (wiki != null) {
+            List<String> results = this.queryManager.createQuery(
+                    ", BaseObject as obj where doc.fullName = obj.name and obj.className = :className", Query.HQL)
+                .setWiki(this.wikiManager.getCurrentWikiId()).bindValue("className", OIDC_USER_CLASS).execute();
+
+            for (String userRef : results) {
+                XWikiDocument userDoc =
+                    wiki.getDocument(documentReferenceResolver.resolve(userRef), xcontextProvider.get());
+                BaseObject oidcObj = userDoc.getXObject(documentReferenceResolver.resolve(OIDC_USER_CLASS));
+                String issuer = oidcObj.getField(ISSUER).toFormString();
+                if (issuer.endsWith(INVALID_VERSION)) {
+                    int index = issuer.lastIndexOf(INVALID_VERSION);
+                    String fixedIssuer = issuer.substring(0, index) + VALID_VERSION;
+                    oidcObj.set(ISSUER, fixedIssuer, xcontextProvider.get());
+                    wiki.saveDocument(userDoc, "Refactored OIDC issuer to the right format used by Entra ID.",
+                        xcontextProvider.get());
+                }
             }
         }
     }
@@ -156,6 +168,18 @@ public class AzureADOIDCMigrator
         return Map.of("authorizationEndpoint", String.format(BASE_ENDPOINT, tenantID, "authorize"), "tokenEndpoint",
             String.format(BASE_ENDPOINT, tenantID, "token"), "logoutEndpoint",
             String.format(BASE_ENDPOINT, tenantID, "logout"));
+    }
+
+    /**
+     * Get the current wiki from context.
+     *
+     * @return the current wiki, or null if the context is not yet initialized.
+     */
+    public XWiki getXWiki()
+    {
+        XWikiContext xcontext = this.xcontextProvider.get();
+
+        return xcontext != null ? xcontext.getWiki() : null;
     }
 
     private Map<String, Object> generateNewConfiguration()

--- a/api/src/main/java/com/xwiki/azureoauth/internal/EntraIDObjectUpdateListener.java
+++ b/api/src/main/java/com/xwiki/azureoauth/internal/EntraIDObjectUpdateListener.java
@@ -19,6 +19,7 @@
  */
 package com.xwiki.azureoauth.internal;
 
+import java.util.List;
 import java.util.Objects;
 
 import javax.inject.Inject;
@@ -29,18 +30,23 @@ import javax.inject.Singleton;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
+import org.xwiki.component.manager.ComponentLookupException;
+import org.xwiki.component.manager.ComponentManager;
 import org.xwiki.component.phase.Initializable;
 import org.xwiki.component.phase.InitializationException;
 import org.xwiki.configuration.ConfigurationSaveException;
+import org.xwiki.configuration.ConfigurationSource;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.EntityReference;
 import org.xwiki.model.reference.WikiReference;
 import org.xwiki.observation.AbstractEventListener;
 import org.xwiki.observation.event.Event;
 import org.xwiki.query.QueryException;
+import org.xwiki.security.authservice.XWikiAuthServiceComponent;
 import org.xwiki.stability.Unstable;
 import org.xwiki.wiki.descriptor.WikiDescriptorManager;
 
+import com.xpn.xwiki.XWiki;
 import com.xpn.xwiki.XWikiException;
 import com.xpn.xwiki.doc.XWikiDocument;
 import com.xpn.xwiki.internal.event.XObjectUpdatedEvent;
@@ -71,6 +77,8 @@ public class EntraIDObjectUpdateListener extends AbstractEventListener implement
     private static final EntityReference CLASS_MATCHER = BaseObjectReference.any("EntraID.Code"
         + ".EntraIDConfigurationClass");
 
+    private static final String DEFAULT_ID = "default";
+
     @Inject
     private WikiDescriptorManager wikiManager;
 
@@ -83,6 +91,13 @@ public class EntraIDObjectUpdateListener extends AbstractEventListener implement
 
     @Inject
     private Provider<AzureADOIDCMigrator> azureOIDCMigratorProvider;
+
+    @Inject
+    @Named("xwikicfg")
+    private ConfigurationSource xwikicfg;
+
+    @Inject
+    private Provider<ComponentManager> componentManagerProvider;
 
     /**
      * Default constructor.
@@ -120,6 +135,13 @@ public class EntraIDObjectUpdateListener extends AbstractEventListener implement
     {
         try {
             AzureADOIDCMigrator azureOIDCMigrator = azureOIDCMigratorProvider.get();
+            XWiki xwiki = azureOIDCMigrator.getXWiki();
+
+            // XWiki might not be fully initialized yet in which case it means we are not installing or reloading the
+            // extension
+            if (xwiki != null) {
+                resetAuthService(xwiki);
+            }
             azureOIDCMigrator.initializeOIDCConfiguration();
             azureOIDCMigrator.refactorOIDCIssuer();
         } catch (XWikiException | QueryException e) {
@@ -149,5 +171,39 @@ public class EntraIDObjectUpdateListener extends AbstractEventListener implement
     private WikiReference getCurrentWikiReference()
     {
         return new WikiReference(this.wikiManager.getCurrentWikiId());
+    }
+
+    private void resetAuthService(XWiki xwiki) throws ComponentLookupException
+    {
+        // Check if an authenticator class is explicitly set (in which case we don't want to override it)
+        String authServiceClass = this.xwikicfg.getProperty("xwiki.authentication.authclass");
+        if (authServiceClass == null) {
+            if (xwiki.getAuthService() instanceof XWikiAuthServiceComponent) {
+                XWikiAuthServiceComponent currentAuth = (XWikiAuthServiceComponent) xwiki.getAuthService();
+                if (Objects.equals(currentAuth.getId(), "oidc") || Objects.equals(currentAuth.getId(), DEFAULT_ID)) {
+                    return;
+                }
+            }
+            registerDefaultService(xwiki);
+        }
+    }
+
+    private void registerDefaultService(XWiki xwiki) throws ComponentLookupException
+    {
+        // Reset the cached auth service so that it's released next time
+        xwiki.setAuthService(null);
+
+        boolean hasDefaultAuthService = componentManagerProvider.get().hasComponent(XWikiAuthServiceComponent.class);
+        if (hasDefaultAuthService) {
+            List<XWikiAuthServiceComponent> authServicesList =
+                this.componentManagerProvider.get().getInstanceList(XWikiAuthServiceComponent.class);
+            for (XWikiAuthServiceComponent authServiceComponent : authServicesList) {
+                // Register the bridge as authenticator
+                if (authServiceComponent.getId().equals(DEFAULT_ID)) {
+                    xwiki.setAuthService(authServiceComponent);
+                    break;
+                }
+            }
+        }
     }
 }

--- a/api/src/main/java/com/xwiki/azureoauth/internal/EntraIDObjectUpdateListener.java
+++ b/api/src/main/java/com/xwiki/azureoauth/internal/EntraIDObjectUpdateListener.java
@@ -181,7 +181,8 @@ public class EntraIDObjectUpdateListener extends AbstractEventListener implement
      * Prior to XWiki 15.3, to be able to select the Authentication service by using the AuthService Backport, the
      * default XWikiAuthServiceComponent needs to be selected. To do this, if the selected authentication service is
      * externally set, we reset it to default one, with the exception if the authentication service is set in xwiki.cfg.
-     * To be removed when upgrading the parent to a version >= 15.3. https://jira.xwiki.org/browse/XWIKI-20548
+     * To be removed when upgrading the parent to a version >= 15.3, in order to include the fix for
+     * XWIKI-20548: Allow choosing the authenticator at runtime.
      */
     private void resetAuthService(XWiki xwiki) throws ComponentLookupException
     {

--- a/api/src/main/java/com/xwiki/azureoauth/internal/EntraIDObjectUpdateListener.java
+++ b/api/src/main/java/com/xwiki/azureoauth/internal/EntraIDObjectUpdateListener.java
@@ -138,7 +138,7 @@ public class EntraIDObjectUpdateListener extends AbstractEventListener implement
             XWiki xwiki = azureOIDCMigrator.getXWiki();
 
             // XWiki might not be fully initialized yet in which case it means we are not installing or reloading the
-            // extension
+            // extension. To be removed when upgrading the XWiki parent to a version >= 15.3.
             if (xwiki != null) {
                 resetAuthService(xwiki);
             }
@@ -173,9 +173,15 @@ public class EntraIDObjectUpdateListener extends AbstractEventListener implement
         return new WikiReference(this.wikiManager.getCurrentWikiId());
     }
 
+    /**
+     * Prior to XWiki 15.3, to be able to select the Authentication service by using the AuthService Backport, the
+     * default XWikiAuthServiceComponent needs to be selected. To do this, we check the selected authentication service
+     * and reset it to default one if externally set, with the exception if the authentication service is set in
+     * xwiki.cfg. To be removed when upgrading the parent to a version >= 15.3.
+     */
     private void resetAuthService(XWiki xwiki) throws ComponentLookupException
     {
-        // Check if an authenticator class is explicitly set (in which case we don't want to override it)
+        // Check if an authenticator class is explicitly set (in which case we don't want to override it).
         String authServiceClass = this.xwikicfg.getProperty("xwiki.authentication.authclass");
         if (authServiceClass == null) {
             if (xwiki.getAuthService() instanceof XWikiAuthServiceComponent) {
@@ -188,9 +194,12 @@ public class EntraIDObjectUpdateListener extends AbstractEventListener implement
         }
     }
 
+    /**
+     * To be removed when upgrading the XWiki parent to a version >= 15.3.
+     */
     private void registerDefaultService(XWiki xwiki) throws ComponentLookupException
     {
-        // Reset the cached auth service so that it's released next time
+        // Reset the cached auth service so that it's released next time.
         xwiki.setAuthService(null);
 
         boolean hasDefaultAuthService = componentManagerProvider.get().hasComponent(XWikiAuthServiceComponent.class);
@@ -198,7 +207,7 @@ public class EntraIDObjectUpdateListener extends AbstractEventListener implement
             List<XWikiAuthServiceComponent> authServicesList =
                 this.componentManagerProvider.get().getInstanceList(XWikiAuthServiceComponent.class);
             for (XWikiAuthServiceComponent authServiceComponent : authServicesList) {
-                // Register the bridge as authenticator
+                // Register the bridge as authenticator.
                 if (authServiceComponent.getId().equals(DEFAULT_ID)) {
                     xwiki.setAuthService(authServiceComponent);
                     break;

--- a/api/src/main/java/com/xwiki/azureoauth/internal/EntraIDObjectUpdateListener.java
+++ b/api/src/main/java/com/xwiki/azureoauth/internal/EntraIDObjectUpdateListener.java
@@ -47,6 +47,7 @@ import org.xwiki.stability.Unstable;
 import org.xwiki.wiki.descriptor.WikiDescriptorManager;
 
 import com.xpn.xwiki.XWiki;
+import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.XWikiException;
 import com.xpn.xwiki.doc.XWikiDocument;
 import com.xpn.xwiki.internal.event.XObjectUpdatedEvent;
@@ -99,6 +100,9 @@ public class EntraIDObjectUpdateListener extends AbstractEventListener implement
     @Inject
     private Provider<ComponentManager> componentManagerProvider;
 
+    @Inject
+    private Provider<XWikiContext> xcontextProvider;
+
     /**
      * Default constructor.
      */
@@ -135,7 +139,7 @@ public class EntraIDObjectUpdateListener extends AbstractEventListener implement
     {
         try {
             AzureADOIDCMigrator azureOIDCMigrator = azureOIDCMigratorProvider.get();
-            XWiki xwiki = azureOIDCMigrator.getXWiki();
+            XWiki xwiki = getXWiki();
 
             // XWiki might not be fully initialized yet in which case it means we are not installing or reloading the
             // extension. To be removed when upgrading the XWiki parent to a version >= 15.3.
@@ -175,9 +179,9 @@ public class EntraIDObjectUpdateListener extends AbstractEventListener implement
 
     /**
      * Prior to XWiki 15.3, to be able to select the Authentication service by using the AuthService Backport, the
-     * default XWikiAuthServiceComponent needs to be selected. To do this, we check the selected authentication service
-     * and reset it to default one if externally set, with the exception if the authentication service is set in
-     * xwiki.cfg. To be removed when upgrading the parent to a version >= 15.3.
+     * default XWikiAuthServiceComponent needs to be selected. To do this, if the selected authentication service is
+     * externally set, we reset it to default one, with the exception if the authentication service is set in xwiki.cfg.
+     * To be removed when upgrading the parent to a version >= 15.3. https://jira.xwiki.org/browse/XWIKI-20548
      */
     private void resetAuthService(XWiki xwiki) throws ComponentLookupException
     {
@@ -214,5 +218,12 @@ public class EntraIDObjectUpdateListener extends AbstractEventListener implement
                 }
             }
         }
+    }
+
+    private XWiki getXWiki()
+    {
+        XWikiContext xcontext = this.xcontextProvider.get();
+
+        return xcontext != null ? xcontext.getWiki() : null;
     }
 }

--- a/api/src/test/java/com/xwiki/azureoauth/internal/AzureADOIDCMigratorTest.java
+++ b/api/src/test/java/com/xwiki/azureoauth/internal/AzureADOIDCMigratorTest.java
@@ -147,6 +147,7 @@ class AzureADOIDCMigratorTest
         when(oauthConfigurationProvider.get()).thenReturn(oauthConfiguration);
         when(entraIDConfigurationProvider.get()).thenReturn(entraIDConfiguration);
         when(wikiContextProvider.get()).thenReturn(wikiContext);
+        when(wikiContext.getWiki()).thenReturn(wiki);
 
         when(oauthConfiguration.getClientID()).thenReturn("client_id");
         when(oauthConfiguration.getScope()).thenReturn("scope1,scope2");

--- a/api/src/test/java/com/xwiki/azureoauth/internal/EntraIDObjectUpdateListenerTest.java
+++ b/api/src/test/java/com/xwiki/azureoauth/internal/EntraIDObjectUpdateListenerTest.java
@@ -20,6 +20,7 @@
 package com.xwiki.azureoauth.internal;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -31,10 +32,15 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.xwiki.component.manager.ComponentLookupException;
+import org.xwiki.component.manager.ComponentManager;
+import org.xwiki.component.phase.InitializationException;
 import org.xwiki.configuration.ConfigurationSaveException;
+import org.xwiki.configuration.ConfigurationSource;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.LocalDocumentReference;
 import org.xwiki.model.reference.WikiReference;
+import org.xwiki.security.authservice.XWikiAuthServiceComponent;
 import org.xwiki.test.LogLevel;
 import org.xwiki.test.annotation.BeforeComponent;
 import org.xwiki.test.junit5.LogCaptureExtension;
@@ -43,6 +49,7 @@ import org.xwiki.test.junit5.mockito.InjectMockComponents;
 import org.xwiki.test.junit5.mockito.MockComponent;
 import org.xwiki.wiki.descriptor.WikiDescriptorManager;
 
+import com.xpn.xwiki.XWiki;
 import com.xpn.xwiki.doc.XWikiDocument;
 import com.xpn.xwiki.internal.event.XObjectUpdatedEvent;
 import com.xwiki.azureoauth.configuration.EntraIDConfiguration;
@@ -87,6 +94,25 @@ class EntraIDObjectUpdateListenerTest
 
     @MockComponent
     private Provider<AzureADOIDCMigrator> azureOIDCMigratorProvider;
+
+    @MockComponent
+    @Named("xwikicfg")
+    private ConfigurationSource xwikicfg;
+
+    @Mock
+    private XWiki xwiki;
+
+    @MockComponent
+    private XWikiAuthServiceComponent defaultAuth;
+
+    @MockComponent
+    private XWikiAuthServiceComponent differentAuth;
+
+    @MockComponent
+    private Provider<ComponentManager> componentManagerProvider;
+
+    @Mock
+    private ComponentManager componentManager;
 
     @Mock
     private XWikiDocument xWikiDocument;
@@ -140,6 +166,53 @@ class EntraIDObjectUpdateListenerTest
         assertEquals(
             "There was an error while trying to update OIDC endpoints. Root cause is: [ConfigurationSaveException: Mock test exception.]",
             logCapture.getMessage(0));
-        assertEquals("org.xwiki.configuration.ConfigurationSaveException: Mock test exception.", exception.getMessage());
+        assertEquals("org.xwiki.configuration.ConfigurationSaveException: Mock test exception.",
+            exception.getMessage());
+    }
+
+    @Test
+    void initializeDefault() throws InitializationException
+    {
+        when(azureADOIDCMigrator.getXWiki()).thenReturn(xwiki);
+        when(xwikicfg.getProperty("xwiki.authentication.authclass")).thenReturn(null);
+        when(defaultAuth.getId()).thenReturn("default");
+        when(xwiki.getAuthService()).thenReturn(defaultAuth);
+        objectUpdateListener.initialize();
+        verify(xwiki, Mockito.times(0)).setAuthService(null);
+    }
+
+    @Test
+    void initializeDifferentNoDefault() throws InitializationException, ComponentLookupException
+    {
+        when(azureADOIDCMigrator.getXWiki()).thenReturn(xwiki);
+        when(xwikicfg.getProperty("xwiki.authentication.authclass")).thenReturn(null);
+        when(differentAuth.getId()).thenReturn("test id");
+        when(xwiki.getAuthService()).thenReturn(differentAuth);
+        when(componentManagerProvider.get()).thenReturn(componentManager);
+        when(componentManager.hasComponent(XWikiAuthServiceComponent.class)).thenReturn(false);
+
+        objectUpdateListener.initialize();
+        verify(xwiki, Mockito.times(1)).setAuthService(null);
+        verify(componentManager, Mockito.times(0)).getInstanceList(XWikiAuthServiceComponent.class);
+    }
+
+    @Test
+    void initializeDifferentDefault() throws InitializationException, ComponentLookupException
+    {
+        when(azureADOIDCMigrator.getXWiki()).thenReturn(xwiki);
+        when(xwikicfg.getProperty("xwiki.authentication.authclass")).thenReturn(null);
+        when(differentAuth.getId()).thenReturn("test id");
+        when(defaultAuth.getId()).thenReturn("default");
+        when(xwiki.getAuthService()).thenReturn(differentAuth);
+        when(componentManagerProvider.get()).thenReturn(componentManager);
+        when(componentManager.hasComponent(XWikiAuthServiceComponent.class)).thenReturn(true);
+
+        when(componentManager.getInstanceList(XWikiAuthServiceComponent.class)).thenReturn(
+            Collections.singletonList(defaultAuth));
+
+        objectUpdateListener.initialize();
+        verify(xwiki, Mockito.times(1)).setAuthService(null);
+        verify(componentManager, Mockito.times(1)).getInstanceList(XWikiAuthServiceComponent.class);
+        verify(xwiki, Mockito.times(1)).setAuthService(defaultAuth);
     }
 }

--- a/api/src/test/java/com/xwiki/azureoauth/internal/EntraIDObjectUpdateListenerTest.java
+++ b/api/src/test/java/com/xwiki/azureoauth/internal/EntraIDObjectUpdateListenerTest.java
@@ -50,6 +50,7 @@ import org.xwiki.test.junit5.mockito.MockComponent;
 import org.xwiki.wiki.descriptor.WikiDescriptorManager;
 
 import com.xpn.xwiki.XWiki;
+import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.doc.XWikiDocument;
 import com.xpn.xwiki.internal.event.XObjectUpdatedEvent;
 import com.xwiki.azureoauth.configuration.EntraIDConfiguration;
@@ -123,6 +124,12 @@ class EntraIDObjectUpdateListenerTest
     @MockComponent
     private AzureADOIDCMigrator azureADOIDCMigrator;
 
+    @MockComponent
+    private Provider<XWikiContext> wikiContextProvider;
+
+    @MockComponent
+    private XWikiContext wikiContext;
+
     private XObjectUpdatedEvent event = new XObjectUpdatedEvent();
 
     private DocumentReference configReference = new DocumentReference(CONFIG_DOC, new WikiReference("mywiki"));
@@ -145,6 +152,8 @@ class EntraIDObjectUpdateListenerTest
         when(entraIDConfiguration.getOIDCTenantID()).thenReturn("old_value");
         when(entraIDConfiguration.getTenantID()).thenReturn("new_value");
         when(azureADOIDCMigrator.getEndpoints("new_value")).thenReturn(configMap);
+        when(wikiContextProvider.get()).thenReturn(wikiContext);
+        when(wikiContext.getWiki()).thenReturn(xwiki);
     }
 
     @Test
@@ -173,7 +182,6 @@ class EntraIDObjectUpdateListenerTest
     @Test
     void initializeDefault() throws InitializationException
     {
-        when(azureADOIDCMigrator.getXWiki()).thenReturn(xwiki);
         when(xwikicfg.getProperty("xwiki.authentication.authclass")).thenReturn(null);
         when(defaultAuth.getId()).thenReturn("default");
         when(xwiki.getAuthService()).thenReturn(defaultAuth);
@@ -184,7 +192,6 @@ class EntraIDObjectUpdateListenerTest
     @Test
     void initializeDifferentNoDefault() throws InitializationException, ComponentLookupException
     {
-        when(azureADOIDCMigrator.getXWiki()).thenReturn(xwiki);
         when(xwikicfg.getProperty("xwiki.authentication.authclass")).thenReturn(null);
         when(differentAuth.getId()).thenReturn("test id");
         when(xwiki.getAuthService()).thenReturn(differentAuth);
@@ -199,7 +206,6 @@ class EntraIDObjectUpdateListenerTest
     @Test
     void initializeDifferentDefault() throws InitializationException, ComponentLookupException
     {
-        when(azureADOIDCMigrator.getXWiki()).thenReturn(xwiki);
         when(xwikicfg.getProperty("xwiki.authentication.authclass")).thenReturn(null);
         when(differentAuth.getId()).thenReturn("test id");
         when(defaultAuth.getId()).thenReturn("default");

--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -46,6 +46,8 @@
     <xwiki.clirr.skip>true</xwiki.clirr.skip>
     <xwiki.revapi.skip>true</xwiki.revapi.skip>
     <xwiki.extension.category>application</xwiki.extension.category>
+    <!-- This module is a leftover dependency from the old Azure OAuth version, and it is no longer needed as its
+      functionalities have been replaced by EntraID OIDC. -->
     <xwiki.extension.features>
       com.xwiki.integration-azure-oauth:integration-azure-oauth-admin-ui
     </xwiki.extension.features>

--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -46,6 +46,9 @@
     <xwiki.clirr.skip>true</xwiki.clirr.skip>
     <xwiki.revapi.skip>true</xwiki.revapi.skip>
     <xwiki.extension.category>application</xwiki.extension.category>
+    <xwiki.extension.features>
+      com.xwiki.integration-azure-oauth:integration-azure-oauth-admin-ui
+    </xwiki.extension.features>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
* manually reset the authentication service when initializing the listener, with the exception when it is set from configuration or already set to oidc
* added a check for XWiki initialization to avoid an error when opening the instance
* adapted test