### PR TITLE
Scope transfer at upgrade breaks login #68

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -60,7 +60,7 @@
     <dependency>
       <groupId>org.xwiki.contrib.oidc</groupId>
       <artifactId>oidc-authenticator</artifactId>
-      <version>2.14.0</version>
+      <version>2.15.0</version>
     </dependency>
     <dependency>
       <groupId>org.xwiki.platform</groupId>

--- a/api/src/main/java/com/xwiki/azureoauth/internal/AzureADOIDCMigrator.java
+++ b/api/src/main/java/com/xwiki/azureoauth/internal/AzureADOIDCMigrator.java
@@ -182,9 +182,6 @@ public class AzureADOIDCMigrator
         Map<String, Object> newConfig = new HashMap<>();
         EntraIDConfiguration entraIDConfiguration = entraIDConfigurationProvider.get();
         AzureOldConfiguration oauthConfiguration = identityOAuthConfigurationProvider.get();
-        if (entraIDConfiguration.getScope().isEmpty()) {
-            newConfig.put("scope", oauthConfiguration.getScope());
-        }
         if (entraIDConfiguration.getClientID().isEmpty()) {
             newConfig.put("clientId", oauthConfiguration.getClientID());
         }

--- a/ui/src/main/resources/EntraID/Code/EntraOIDCClientConfiguration.xml
+++ b/ui/src/main/resources/EntraID/Code/EntraOIDCClientConfiguration.xml
@@ -370,6 +370,15 @@
       <defaultWeb/>
       <nameField/>
       <validationScript/>
+      <afterLogoutURL>
+        <disabled>0</disabled>
+        <name>afterLogoutURL</name>
+        <number>30</number>
+        <prettyName>URL after Logout</prettyName>
+        <size>255</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </afterLogoutURL>
       <allowedGroups>
         <contenttype>PureText</contenttype>
         <disabled>0</disabled>
@@ -670,6 +679,9 @@
       </xwikiProvider>
     </class>
     <property>
+      <afterLogoutURL/>
+    </property>
+    <property>
       <allowedGroups/>
     </property>
     <property>
@@ -715,7 +727,7 @@
       <responseType>code</responseType>
     </property>
     <property>
-      <scope/>
+      <scope>openid,profile,email,address</scope>
     </property>
     <property>
       <skipped>0</skipped>


### PR DESCRIPTION
Removed scope transfer at application upgrade and added default scope value. 
Updated the OIDC version and the OIDC.ClientConfigurationClass object.