### PR TITLE
Handle Apache Commons Lang 2 dependency issue for XWiki version 17.6.x #78

### DIFF
--- a/api/src/main/java/com/xwiki/azureoauth/internal/rest/DefaultEntraIDResource.java
+++ b/api/src/main/java/com/xwiki/azureoauth/internal/rest/DefaultEntraIDResource.java
@@ -28,7 +28,7 @@ import javax.inject.Singleton;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 
-import org.apache.commons.lang.exception.ExceptionUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.rest.XWikiRestException;


### PR DESCRIPTION
Modified `apache.commons.lang` dependency from version 2 to 3.