### PR TITLE
The Sync EntraID Users feature is not working on local XWiki 15.10 for 2.1-rc-2 #92

### DIFF
--- a/api/src/main/java/com/xwiki/azureoauth/internal/rest/DefaultEntraIDResource.java
+++ b/api/src/main/java/com/xwiki/azureoauth/internal/rest/DefaultEntraIDResource.java
@@ -21,6 +21,7 @@ package com.xwiki.azureoauth.internal.rest;
 
 import java.net.URI;
 import java.util.List;
+import java.util.Map;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -90,11 +91,15 @@ public class DefaultEntraIDResource implements EntraIDResource
     }
 
     @Override
-    public Response syncUsers(String disable, String remove) throws XWikiRestException
+    public Response syncUsers() throws XWikiRestException
     {
         try {
             contextualAuthorizationManager.checkAccess(Right.ADMIN);
-            logger.debug("Received actions: disabled [{}]; remove [{}]", disable, remove);
+            Map<String, String[]> parameters = wikiContextProvider.get().getRequest().getParameterMap();
+            String disable = parameters.get("disable")[0];
+            String remove = parameters.get("remove")[0];
+            logger.debug("Requested actions: disabled [{}]; remove [{}]", disable, remove);
+
             List<String> jobId = List.of("entra", "users", "sync", disable, remove);
             Job job = this.jobExecutor.getJob(jobId);
             if (job == null) {

--- a/api/src/main/java/com/xwiki/azureoauth/rest/EntraIDResource.java
+++ b/api/src/main/java/com/xwiki/azureoauth/rest/EntraIDResource.java
@@ -19,8 +19,6 @@
  */
 package com.xwiki.azureoauth.rest;
 
-import javax.ws.rs.DefaultValue;
-import javax.ws.rs.FormParam;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -55,8 +53,6 @@ public interface EntraIDResource extends XWikiRestComponent
     /**
      * Sync XWiki users with the users from Entra ID.
      *
-     * @param disable flag if the user sync operation should synchronize disabled users from Entra ID
-     * @param remove flag if the user sync operation should synchronize removed users from Entra ID
      * @return status code 201 if a new job has been created, or status code 200 if a job with the same ID already
      *     exists
      * @throws XWikiRestException with status code 401 if the user requesting is missing admin rights, or code 500
@@ -66,6 +62,5 @@ public interface EntraIDResource extends XWikiRestComponent
     @POST
     @Path("/user/sync")
     @Unstable
-    Response syncUsers(@FormParam("disable") @DefaultValue("false") String disable,
-        @FormParam("remove") @DefaultValue("false") String remove) throws XWikiRestException;
+    Response syncUsers() throws XWikiRestException;
 }


### PR DESCRIPTION
Refactored endpoint implementation to get the parameters from the request.

Tested locally on XWiki 15.10 and XWiki 16.10.8